### PR TITLE
Handle empty API responses by raising an APIError

### DIFF
--- a/lib/exchange/external_api/call.rb
+++ b/lib/exchange/external_api/call.rb
@@ -1,14 +1,14 @@
 # -*- encoding : utf-8 -*-
 module Exchange
   module ExternalAPI
-    
+
     # A class to handle API calls in a standardized way for all APIs
     # @author Beat Richartz
     # @version 0.1
     # @since 0.1
     #
     class Call < Base
-      
+
       # Initialization of the Call class is the call itself. This means that every instance of the class will only exist during the call
       # @param [String] url The url of the API to call
       # @param [Hash] options The options of the API call
@@ -33,19 +33,19 @@ module Exchange
       #
       def initialize url, options={}, &block
         Exchange::GemLoader.new(options[:format] == :xml ? 'nokogiri' : 'json').try_load
-                
+
         result = cache_config.subclass.cached(options[:api] || config.subclass, options) do
           load_url(url, options[:retries] || config.retries, options[:retry_with])
         end
-        
+
         parsed = options[:format] == :xml ? Nokogiri::XML.parse(result.sub("\n", '')) : ::JSON.load(result)
-        
+
         return parsed unless block_given?
         yield  parsed
       end
-      
+
       private
-      
+
         # A helper function to load the API URL with
         # @param [String] url The url to be loaded
         # @param [Integer] retries The number of retries to do if the API Call should fail with a HTTP Error
@@ -53,7 +53,7 @@ module Exchange
         # @todo install a timeout for slow requests, but respect when loading large files
         #
         def load_url url, retries, retry_with
-          begin            
+          begin
             result = URI.parse(url).open.read
           rescue SocketError
             raise APIError.new("Calling API #{url} produced a socket error")
@@ -66,14 +66,17 @@ module Exchange
               raise APIError.new("API #{url} was not reachable and returned #{e.message}. May be you requested a historic rate not provided")
             end
           end
+          if result == ''
+            raise APIError.new("API #{url} returned a blank response")
+          end
           result
         end
-      
+
     end
-    
+
     # The Api Error to throw when an API Call fails
     #
     APIError = Class.new Error
-    
+
   end
 end

--- a/spec/exchange/external_api/call_spec.rb
+++ b/spec/exchange/external_api/call_spec.rb
@@ -82,4 +82,12 @@ describe "Exchange::ExternalAPI::Call" do
       end
     end
   end
+  context "with an api returning blank responses" do
+    before(:each) { mock_api('BLANK_API', '') }
+
+    it "should raise an error" do
+      expect { Exchange::ExternalAPI::Call.new('BLANK_API') }.
+        to raise_error(Exchange::ExternalAPI::APIError, /blank/)
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/pocketsmith/exchange/issues/9

If an API returns a blank string on us (usually because they're down / the load balancer is throwing a tanty) let's handle that, which we've found in our experience has happened historically with Open Exchange Rates.